### PR TITLE
CodeAid/Fixed ef3ef3ca-2c4d-4e96-b261-06ddb910fcfd

### DIFF
--- a/server/app/index.js
+++ b/server/app/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
 var express = require('express');
+var csrf = require('csurf');
 var app = express();
 
 module.exports = function (db) {
@@ -13,6 +14,8 @@ module.exports = function (db) {
     // /api so they are isolated from our GET /* wildcard.
     app.use('/api', require('./routes'));
 
+    // CSRF middleware
+    app.use(csrf());
 
     /*
      This middleware will catch any URLs resembling a file extension
@@ -44,4 +47,3 @@ module.exports = function (db) {
     return app;
 
 };
-

--- a/test/server/app/index.js
+++ b/test/server/app/index.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import express from 'express';
+import request from 'supertest';
+
+describe('CSRF Middleware', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  it('should return 404 for URLs with file extensions', (done) => {
+    app.use(require('../middleware/csrf'));
+
+    request(app)
+      .get('/api/test.js')
+      .expect(404)
+      .end(done);
+  });
+
+  it('should call next for URLs without file extensions', (done) => {
+    const next = sinon.spy();
+    app.use(require('../middleware/csrf'));
+
+    request(app)
+      .get('/api/test')
+      .end(() => {
+        expect(next.called).to.be.true;
+        done();
+      });
+  });
+
+  it('should return index.html for all other URLs', (done) => {
+    app.use(require('../middleware/csrf'));
+
+    request(app)
+      .get('/api/test')
+      .expect('Content-Type', 'text/html')
+      .expect(200)
+      .end(done);
+  });
+});


### PR DESCRIPTION
## What did you do? 
 - Fixed the security issue by CodeAid
## Why did you do it? 
 - A CSRF middleware was not detected in your express application. Ensure you are either using one such as `csurf` or `csrf` (see rule references) and/or you are properly doing CSRF validation in your routes with a token or cookies.